### PR TITLE
Add ng-add so you can do 'ng add @okta/shield'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,16 @@ First, create an empty project with Angular CLI. You **must** add Angular routin
 ng new my-secure-app --routing
 ```
 
-Then in your new project, add `@oktadev/schematics` and run the `add-auth` schematic:
+Then in your new project, add `@oktadev/schematics`:
 
 ```
 npm i @oktadev/schematics
+ng add @oktadev/schematics
+```
+
+You can also use the following syntax:
+
+```
 ng g @oktadev/schematics:add-auth
 ```
 

--- a/src/collection.json
+++ b/src/collection.json
@@ -5,6 +5,11 @@
       "factory": "./add-auth/index#addAuth",
       "description": "Update an application with Okta Auth defaults.",
       "schema": "./add-auth/schema.json"
+    },
+    "ng-add": {
+      "factory": "./add-auth/index#addAuth",
+      "description": "Add @okta/okta-angular and configure for an OIDC app.",
+      "schema": "./add-auth/schema.json"
     }
   }
 }

--- a/src/ng-add/index.ts
+++ b/src/ng-add/index.ts
@@ -1,0 +1,18 @@
+import {
+  Rule,
+  SchematicContext,
+  Tree,
+  chain,
+  externalSchematic,
+} from '@angular-devkit/schematics';
+
+export default function(options: any): Rule {
+  return (host: Tree, context: SchematicContext) => {
+    return chain([
+      externalSchematic('@okta/shield', 'add-auth', {
+        ...options,
+        root: true,
+      }),
+    ])(host, context);
+  };
+}

--- a/src/ng-add/index.ts
+++ b/src/ng-add/index.ts
@@ -9,7 +9,7 @@ import {
 export default function(options: any): Rule {
   return (host: Tree, context: SchematicContext) => {
     return chain([
-      externalSchematic('@okta/shield', 'add-auth', {
+      externalSchematic('@oktadev/schematics', 'add-auth', {
         ...options,
         root: true,
       }),

--- a/test-app.sh
+++ b/test-app.sh
@@ -2,12 +2,12 @@
 
 framework="$1"
 
-if [ "$1" == "angular" ]
+if [ "$1" == "angular" ] || [ "$1" == "a" ]
 then
   ng new my-secure-app --routing --style CSS
   cd my-secure-app
   npm link @oktadev/schematics
-  ng g @oktadev/schematics:add-auth --issuer=https://developer.okta.com --clientId=foobar
+  ng add @oktadev/schematics --issuer=https://developer.okta.com --clientId=foobar
   ng test --watch=false && ng e2e
 else
   echo "This script only supports Angular at this time."


### PR DESCRIPTION
This currently fails:

```
ng add @okta/shield
Installing packages for tooling via npm.
npm ERR! code E404
npm ERR! 404 Not Found: @okta/shield@latest
```

It might work after this module is published to npm.