### PR TITLE
Downgrade Okta Angular SDK to 1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@angular-devkit/core": {
-      "version": "8.3.20",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-8.3.20.tgz",
-      "integrity": "sha512-UCfW/BJBJnioJU34QennQhA4o+rLoCXWiSrI2LM7yw8/MEM9I8KbqRETP1My3HjHkQnvP+Qh3noedpcu3Nnt8A==",
+      "version": "8.3.21",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-8.3.21.tgz",
+      "integrity": "sha512-BYyVbrbys535FplX0+GVOlYBg/cyk1U5SRhSxRRFZYi9epVlEBBPk8/6wV4cQPGb6EwXkVj7YtPWXjXcGfzWmA==",
       "requires": {
         "ajv": "6.10.2",
         "fast-json-stable-stringify": "2.0.0",
@@ -57,15 +57,6 @@
         }
       }
     },
-    "@angular/cdk": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-8.2.3.tgz",
-      "integrity": "sha512-ZwO5Sn720RA2YvBqud0JAHkZXjmjxM0yNzCO8RVtRE9i8Gl26Wk0j0nQeJkVm4zwv2QO8MwbKUKGTMt8evsokA==",
-      "requires": {
-        "parse5": "^5.0.0",
-        "tslib": "^1.7.1"
-      }
-    },
     "@schematics/angular": {
       "version": "8.3.21",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-8.3.21.tgz",
@@ -98,12 +89,12 @@
       }
     },
     "@schematics/update": {
-      "version": "0.803.17",
-      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.803.17.tgz",
-      "integrity": "sha512-42CqIcm0i1BfBXYm6YuE8Q6kEEb0ATYiPYJQTgmb+bZSF2Sl9eAzPBaackW2EwVK1JP3Rdyl2S31OwGvgAk6xA==",
+      "version": "0.803.21",
+      "resolved": "https://registry.npmjs.org/@schematics/update/-/update-0.803.21.tgz",
+      "integrity": "sha512-D3BRvEBF2cJEgogvFaNOfqtTFHHv/ctSRfOeAYWjUxILtb+2DpuZ9h5QYDFhN9MPgz/vRaOqFORa3sEZCRkX4g==",
       "requires": {
-        "@angular-devkit/core": "8.3.17",
-        "@angular-devkit/schematics": "8.3.17",
+        "@angular-devkit/core": "8.3.21",
+        "@angular-devkit/schematics": "8.3.21",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "1.3.5",
         "pacote": "9.5.5",
@@ -112,27 +103,6 @@
         "semver-intersect": "1.4.0"
       },
       "dependencies": {
-        "@angular-devkit/core": {
-          "version": "8.3.17",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-8.3.17.tgz",
-          "integrity": "sha512-cR2H/7OxxqagwGfzxwNWDOYN4QpOZ56Fei9JED/2p/K/5UDAowl20o3qP9mTfia/lEhFeyjMBcM8gsHxhJNYJQ==",
-          "requires": {
-            "ajv": "6.10.2",
-            "fast-json-stable-stringify": "2.0.0",
-            "magic-string": "0.25.3",
-            "rxjs": "6.4.0",
-            "source-map": "0.7.3"
-          }
-        },
-        "@angular-devkit/schematics": {
-          "version": "8.3.17",
-          "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-8.3.17.tgz",
-          "integrity": "sha512-1ttzYGnw5Ux7Nfr/TGyWx3C/rarq5l+dn+5SpKof/8ctvQU1gJaswF492ngPs/jDjaPq5MucKYoX+wTUJHnUhg==",
-          "requires": {
-            "@angular-devkit/core": "8.3.17",
-            "rxjs": "6.4.0"
-          }
-        },
         "rxjs": {
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
@@ -156,9 +126,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.21.tgz",
-      "integrity": "sha512-8sRGhbpU+ck1n0PGAUgVrWrWdjSW2aqNeyC15W88GRsMpSwzv6RJGlLhE7s2RhVSOdyDmxbqlWSeThq4/7xqlA==",
+      "version": "13.1.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.4.tgz",
+      "integrity": "sha512-Lue/mlp2egZJoHXZr4LndxDAd7i/7SQYhV0EjWfb/a4/OZ6tuVwMCVPiwkU5nsEipxEf7hmkSU7Em5VQ8P5NGA==",
       "dev": true
     },
     "@yarnpkg/lockfile": {
@@ -251,9 +221,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bluebird": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
-      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -297,9 +267,9 @@
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
-          "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -854,9 +824,9 @@
       }
     },
     "make-fetch-happen": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.1.tgz",
-      "integrity": "sha512-b4dfaMvUDR67zxUq1+GN7Ke9rH5WvGRmoHuMH7l+gmUCR2tCXFP6mpeJ9Dp+jB6z8mShRopSf1vLRBhRs8Cu5w==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz",
+      "integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
       "requires": {
         "agentkeepalive": "^3.4.1",
         "cacache": "^12.0.0",
@@ -996,9 +966,17 @@
       }
     },
     "npm-bundled": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
-      "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
     },
     "npm-package-arg": {
       "version": "6.1.1",
@@ -1019,9 +997,9 @@
       }
     },
     "npm-packlist": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.6.tgz",
-      "integrity": "sha512-u65uQdb+qwtGvEJh/DgQgW1Xg7sqeNbmxYyrvlNznaVTjV3E5P6F/EFjM+BVHXl7JJlsdG8A64M0XI8FI/IOlg==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.7.tgz",
+      "integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
       "requires": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1"
@@ -1153,9 +1131,9 @@
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
-          "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -1183,9 +1161,9 @@
       }
     },
     "parse5": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-      "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
       "optional": true
     },
     "path-is-absolute": {
@@ -1267,9 +1245,9 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -1288,9 +1266,9 @@
       }
     },
     "resolve": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz",
+      "integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -1309,9 +1287,9 @@
       },
       "dependencies": {
         "glob": {
-          "version": "7.1.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.5.tgz",
-          "integrity": "sha512-J9dlskqUXK1OeTOYBEn5s8aMukWMwWfs+rPTn/jn50Ux4MNXVhubL1wu/j2t+H4NVI+cXEcCaYellqaPVGXNqQ==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -1350,15 +1328,14 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "schematics-utilities": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/schematics-utilities/-/schematics-utilities-2.0.0.tgz",
-      "integrity": "sha512-Udfhw9KhrvJBb+JiHsc0SGnr2vui3kWf9ceBhHdBPYlMoChjqJ1WR8w47sOj37Wsel7jtl/8TRt53RJmXtZXjw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/schematics-utilities/-/schematics-utilities-2.0.1.tgz",
+      "integrity": "sha512-8tOOrWfBLayBefH/9Gdj+4oZ9aO+joRy4sZeQQ1l/rEaPt+bdZchEgllTz5rz0L/nX0Q/vYUmKXZiPEt0LOiWg==",
       "requires": {
-        "@angular-devkit/core": "^8.3.8",
-        "@angular-devkit/schematics": "^8.3.8",
-        "@angular/cdk": "^8.2.2",
-        "@schematics/angular": "^8.3.8",
-        "@schematics/update": "^0.803.8",
+        "@angular-devkit/core": "^8.3.21",
+        "@angular-devkit/schematics": "^8.3.21",
+        "@schematics/angular": "^8.3.21",
+        "@schematics/update": "^0.803.21",
         "parse5": "^5.1.0",
         "rxjs": "^6.4.0",
         "typescript": "^3.6.3"
@@ -1385,17 +1362,17 @@
       }
     },
     "smart-buffer": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.0.2.tgz",
-      "integrity": "sha512-JDhEpTKzXusOqXZ0BUIdH+CjFdO/CR3tLlf5CN34IypI+xMmXW1uB16OOY8z3cICbJlDAVJzNbwBhNO0wt9OAw=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
     },
     "socks": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.2.tgz",
-      "integrity": "sha512-pCpjxQgOByDHLlNqlnh/mNSAxIUkyBBuwwhTcV+enZGbDaClPvHdvm6uvOwZfFJkam7cGhBNbb4JxiP8UZkRvQ==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
+      "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
       "requires": {
-        "ip": "^1.1.5",
-        "smart-buffer": "4.0.2"
+        "ip": "1.1.5",
+        "smart-buffer": "^4.1.0"
       }
     },
     "socks-proxy-agent": {
@@ -1479,9 +1456,9 @@
       }
     },
     "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "string_decoder": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,15 @@
         }
       }
     },
+    "@angular/cdk": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-8.2.3.tgz",
+      "integrity": "sha512-ZwO5Sn720RA2YvBqud0JAHkZXjmjxM0yNzCO8RVtRE9i8Gl26Wk0j0nQeJkVm4zwv2QO8MwbKUKGTMt8evsokA==",
+      "requires": {
+        "parse5": "^5.0.0",
+        "tslib": "^1.7.1"
+      }
+    },
     "@schematics/angular": {
       "version": "8.3.21",
       "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-8.3.21.tgz",
@@ -1328,14 +1337,15 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "schematics-utilities": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/schematics-utilities/-/schematics-utilities-2.0.1.tgz",
-      "integrity": "sha512-8tOOrWfBLayBefH/9Gdj+4oZ9aO+joRy4sZeQQ1l/rEaPt+bdZchEgllTz5rz0L/nX0Q/vYUmKXZiPEt0LOiWg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/schematics-utilities/-/schematics-utilities-2.0.0.tgz",
+      "integrity": "sha512-Udfhw9KhrvJBb+JiHsc0SGnr2vui3kWf9ceBhHdBPYlMoChjqJ1WR8w47sOj37Wsel7jtl/8TRt53RJmXtZXjw==",
       "requires": {
-        "@angular-devkit/core": "^8.3.21",
-        "@angular-devkit/schematics": "^8.3.21",
-        "@schematics/angular": "^8.3.21",
-        "@schematics/update": "^0.803.21",
+        "@angular-devkit/core": "^8.3.8",
+        "@angular-devkit/schematics": "^8.3.8",
+        "@angular/cdk": "^8.2.2",
+        "@schematics/angular": "^8.3.8",
+        "@schematics/update": "^0.803.8",
         "parse5": "^5.1.0",
         "rxjs": "^6.4.0",
         "typescript": "^3.6.3"

--- a/package.json
+++ b/package.json
@@ -24,15 +24,15 @@
   "repository": "git@github.com:oktadeveloper/schematics.git",
   "schematics": "./src/collection.json",
   "dependencies": {
-    "@angular-devkit/core": "8.3.20",
+    "@angular-devkit/core": "8.3.21",
     "@angular-devkit/schematics": "8.3.21",
     "@schematics/angular": "8.3.21",
     "rxjs": "6.5.4",
-    "schematics-utilities": "2.0.0"
+    "schematics-utilities": "2.0.1"
   },
   "devDependencies": {
     "@types/jasmine": "3.5.0",
-    "@types/node": "12.12.21",
+    "@types/node": "13.1.4",
     "chalk": "3.0.0",
     "istanbul": "0.4.5",
     "jasmine": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@angular-devkit/schematics": "8.3.21",
     "@schematics/angular": "8.3.21",
     "rxjs": "6.5.4",
-    "schematics-utilities": "2.0.1"
+    "schematics-utilities": "2.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "3.5.0",

--- a/src/add-auth/index.ts
+++ b/src/add-auth/index.ts
@@ -28,7 +28,7 @@ function addPackageJsonDependencies(framework: string, options: any): Rule {
     const dependencies: NodeDependency[] = [];
 
     if (framework === ANGULAR) {
-      dependencies.push({type: NodeDependencyType.Default, version: '1.3.0', name: '@okta/okta-angular'})
+      dependencies.push({type: NodeDependencyType.Default, version: '1.2.2', name: '@okta/okta-angular'})
     } else if (framework === REACT || framework === REACT_TS) {
       dependencies.push({type: NodeDependencyType.Default, version: '1.3.0', name: '@okta/okta-react'});
       dependencies.push({type: NodeDependencyType.Default, version: '5.1.2', name: 'react-router-dom'});


### PR DESCRIPTION
Downgrade Angular to 1.2.2 from 1.3.0 because [1.3.0 doesn't work with Angular 9](https://github.com/okta/okta-oidc-js/issues/643).