### PR TITLE
Save to devDependencies by default when ng add is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
   },
   "resolutions": {
     "handlebars": "4.5.3"
+  },
+  "ng-add": {
+    "save": "devDependencies"
   }
 }


### PR DESCRIPTION
This PR adds a setting for `ng add`to save the package to `devDependencies` by default (if this is supported by the installed Angular CLI version).

See also https://github.com/angular/angular-cli/pull/15815